### PR TITLE
Remove due_date from models

### DIFF
--- a/backend/migrations/versions/3d4e5f6g7h8i_remove_due_date_from_jobs.py
+++ b/backend/migrations/versions/3d4e5f6g7h8i_remove_due_date_from_jobs.py
@@ -1,0 +1,36 @@
+"""Remove due_date column from jobs table
+
+Revision ID: 3d4e5f6g7h8i
+Revises: 2ce8bc4cb093
+Create Date: 2025-01-24 11:03:04.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3d4e5f6g7h8i'
+down_revision: Union[str, None] = '2ce8bc4cb093'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Drop indexes that reference due_date column
+    op.drop_index('idx_job_due_date_status', table_name='jobs')
+    op.drop_index(op.f('ix_jobs_due_date'), table_name='jobs')
+    
+    # Drop the due_date column
+    op.drop_column('jobs', 'due_date')
+
+
+def downgrade() -> None:
+    # Add the due_date column back
+    op.add_column('jobs', sa.Column('due_date', sa.DateTime(), nullable=True))
+    
+    # Recreate indexes
+    op.create_index(op.f('ix_jobs_due_date'), 'jobs', ['due_date'], unique=False)
+    op.create_index('idx_job_due_date_status', 'jobs', ['due_date', 'status'], unique=False)

--- a/backend/models/models.py
+++ b/backend/models/models.py
@@ -554,7 +554,6 @@ class Job(Base):
     estimated_hours = Column(Integer, index=True)
     actual_hours = Column(Integer, index=True)
     priority = Column(Enum(IssuePriority), nullable=False, default=IssuePriority.MEDIUM, index=True)
-    due_date = Column(DateTime, index=True)
     started_at = Column(DateTime, index=True)
     completed_at = Column(DateTime, index=True)
     created_at = Column(DateTime, server_default=func.now(), index=True)
@@ -574,7 +573,6 @@ class Job(Base):
         Index('idx_job_room_status', 'room_id', 'status'),
         Index('idx_job_topic_status', 'topic_id', 'status'),
         Index('idx_job_created_by_date', 'created_by_id', 'created_at'),
-        Index('idx_job_due_date_status', 'due_date', 'status'),
         Index('idx_job_priority_status', 'priority', 'status'),
     )
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -570,7 +570,6 @@ class JobBase(BaseSchema):
     estimated_hours: Optional[int] = Field(None, ge=0, description="Estimated hours to complete")
     actual_hours: Optional[int] = Field(None, ge=0, description="Actual hours spent")
     priority: IssuePriority = Field(IssuePriority.MEDIUM, description="Job priority")
-    due_date: Optional[datetime] = Field(None, description="Due date for job completion")
 
 class JobCreate(JobBase):
     created_by_id: int = Field(..., description="User ID who created the job")
@@ -586,7 +585,6 @@ class JobUpdate(BaseSchema):
     estimated_hours: Optional[int] = Field(None, ge=0)
     actual_hours: Optional[int] = Field(None, ge=0)
     priority: Optional[IssuePriority] = None
-    due_date: Optional[datetime] = None
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
 


### PR DESCRIPTION
Remove 'due_date' field from Job model, schemas, and database.

---

[Open in Web](https://www.cursor.com/agents?id=bc-8b269236-dca4-49a3-a25f-70d793d76215) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8b269236-dca4-49a3-a25f-70d793d76215)