### PR TITLE
Fix nextjs permission errors

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -5,11 +5,22 @@ WORKDIR /app
 # Install curl for health checks
 RUN apk add --no-cache curl
 
+# Create a non-root user with proper permissions (matching host user)
+RUN addgroup --system --gid 1000 nodejs
+RUN adduser --system --uid 1000 nextjs
+
 # Copy package.json and package-lock.json
 COPY package*.json ./
 
 # Install dependencies
 RUN npm ci
+
+# Create necessary directories and set permissions
+RUN mkdir -p .next && \
+    chown -R nextjs:nodejs /app
+
+# Switch to non-root user
+USER nextjs
 
 EXPOSE 3000
 


### PR DESCRIPTION
Fix Next.js development container permission errors by adding a non-root user and setting proper directory ownership.

The `EACCES: permission denied` errors occurred because the Next.js development server, when running inside the Docker container with volume mounts, lacked the necessary write permissions for files like `next-env.d.ts` and the `.next/trace` directory. This PR resolves the issue by creating a non-root user (`nextjs`) with a UID matching the host (1000), setting correct ownership for the `/app` directory and its contents, and running the development server as this user. This ensures Next.js can create and modify files within the mounted volume without permission conflicts.

---

[Open in Web](https://www.cursor.com/agents?id=bc-45130b97-3d33-45e9-a747-1b2747afee26) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-45130b97-3d33-45e9-a747-1b2747afee26)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)