### PR TITLE
Fix next env file permission error

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -29,3 +29,4 @@ services:
       - ./frontend:/app
       - /app/node_modules
       - /app/.next
+    user: "1001:1001"

--- a/fix-permissions.sh
+++ b/fix-permissions.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Fix permissions for Next.js development
+echo "Fixing permissions for Next.js development..."
+
+# Create next-env.d.ts if it doesn't exist
+if [ ! -f "frontend/next-env.d.ts" ]; then
+    echo "Creating next-env.d.ts..."
+    touch frontend/next-env.d.ts
+fi
+
+# Set proper permissions for the frontend directory
+# Make sure the files are readable/writable by user and group
+find frontend -type f -exec chmod 664 {} \;
+find frontend -type d -exec chmod 775 {} \;
+
+# Specifically handle next-env.d.ts
+chmod 664 frontend/next-env.d.ts
+
+# Create .next directory if it doesn't exist
+mkdir -p frontend/.next
+chmod 775 frontend/.next
+
+echo "Permissions fixed successfully!"
+echo "You can now run: docker-compose up --build"

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -4,9 +4,9 @@ WORKDIR /app
 # Install curl for health checks
 RUN apk add --no-cache curl
 
-# Create a non-root user (system will assign available IDs)
-RUN addgroup --system nodejs
-RUN adduser --system --ingroup nodejs nextjs
+# Create a non-root user with specific IDs to match host
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 --ingroup nodejs nextjs
 
 # Copy package.json and package-lock.json
 COPY package*.json ./
@@ -14,9 +14,11 @@ COPY package*.json ./
 # Install dependencies
 RUN npm ci
 
-# Create necessary directories and set permissions
+# Create necessary directories and files, set permissions
 RUN mkdir -p .next && \
-    chown -R nextjs:nodejs /app
+    touch next-env.d.ts && \
+    chown -R nextjs:nodejs /app && \
+    chmod -R 755 /app
 
 # Switch to non-root user
 USER nextjs


### PR DESCRIPTION
Fix EACCES permission errors for Next.js in Docker development.

The Next.js container failed to start due to `EACCES` errors on `next-env.d.ts`. This was caused by permission mismatches between the host-mounted volume and the `nextjs` user inside the container, as well as the initial absence of the `next-env.d.ts` file.

---

[Open in Web](https://www.cursor.com/agents?id=bc-6be03d03-e95e-465f-a9cd-c293e6931e2b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6be03d03-e95e-465f-a9cd-c293e6931e2b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)