### PR TITLE
Handle bcrypt attribute error during startup

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ email-validator==2.1.0
 python-multipart==0.0.19
 sqladmin==0.16.0
 passlib[bcrypt]==1.7.4
-bcrypt==4.1.2
+bcrypt==3.2.2
 requests==2.31.0
 redis==5.0.1
 celery==5.3.4


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Downgrade bcrypt to fix `AttributeError` caused by incompatibility with passlib.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `passlib==1.7.4` library is incompatible with `bcrypt>=4.0.0` because newer bcrypt versions removed the `__about__` attribute that passlib attempts to access. Downgrading `bcrypt` to `3.2.2` resolves this version mismatch, eliminating the `AttributeError: module 'bcrypt' has no attribute '__about__'` traceback.

---
<a href="https://cursor.com/background-agent?bcId=bc-da0e73e8-a5ee-4605-90f5-432389812f34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da0e73e8-a5ee-4605-90f5-432389812f34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>