### PR TITLE
Check frontend container status

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -135,6 +135,8 @@ services:
       - BACKEND_URL=http://fastapi:8000
       - NEXT_PUBLIC_BACKEND_URL=${NEXT_PUBLIC_BACKEND_URL}
       - NEXT_TELEMETRY_DISABLED=1
+    ports:
+      - "3000:3000"
     restart: always
     networks:
       - pm_network


### PR DESCRIPTION
Expose frontend service port 3000 in `docker-compose.prod.yml` to allow direct access from the host.

---
<a href="https://cursor.com/background-agent?bcId=bc-de37f7ff-f88e-46f7-a236-5cf8bfb86429">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de37f7ff-f88e-46f7-a236-5cf8bfb86429">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>