### PR TITLE
Check container status and resolve port conflict

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -135,8 +135,8 @@ services:
       - BACKEND_URL=http://fastapi:8000
       - NEXT_PUBLIC_BACKEND_URL=${NEXT_PUBLIC_BACKEND_URL}
       - NEXT_TELEMETRY_DISABLED=1
-    ports:
-      - "3000:3000"
+    expose:
+      - "3000"
     restart: always
     networks:
       - pm_network

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -87,15 +87,15 @@ http {
     # Upstream servers with load balancing
     upstream fastapi_backend {
         least_conn;
-        server workspace-fastapi-1:8000 max_fails=3 fail_timeout=30s;
-        server workspace-fastapi-2:8000 max_fails=3 fail_timeout=30s;
+        server fast-fastapi-1:8000 max_fails=3 fail_timeout=30s;
+        server fast-fastapi-2:8000 max_fails=3 fail_timeout=30s;
         keepalive 32;
     }
 
     upstream nextjs_frontend {
         least_conn;
-        server workspace-frontend-1:3000 max_fails=3 fail_timeout=30s;
-        server workspace-frontend-2:3000 max_fails=3 fail_timeout=30s;
+        server fast-frontend-1:3000 max_fails=3 fail_timeout=30s;
+        server fast-frontend-2:3000 max_fails=3 fail_timeout=30s;
         keepalive 32;
     }
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix port allocation error for scaled frontend service and update Nginx upstream names.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `docker-compose.prod.yml` was configured to run two frontend replicas, but both were trying to bind to host port 3000, causing a "port already allocated" error. Removing the explicit `ports` mapping and using `expose` allows Docker Compose to manage internal port allocation for scaled services, with Nginx handling external access. Additionally, Nginx upstream names were updated to match the actual container names (e.g., `fast-frontend-1` instead of `workspace-frontend-1`).

---
<a href="https://cursor.com/background-agent?bcId=bc-3be4abc0-05d9-4852-b704-d12009f4b044">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3be4abc0-05d9-4852-b704-d12009f4b044">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>