### PR TITLE
Check container status and resolve port conflict

### DIFF
--- a/SCALING.md
+++ b/SCALING.md
@@ -1,0 +1,61 @@
+# Docker Compose Scaling Setup
+
+## Problem Solved
+The original error was caused by trying to scale the frontend service while having a fixed port mapping (`3000:3000`). When scaling to 2 instances, both containers tried to bind to the same host port 3000, causing a conflict.
+
+## Changes Made
+
+### 1. Removed Fixed Container Names
+- Removed `container_name` from `fastapi` and `frontend` services
+- This allows Docker Compose to create multiple instances with auto-generated names
+
+### 2. Changed Port Mapping to Expose
+- Changed `ports: - "3000:3000"` to `expose: - "3000"` for frontend
+- Changed `ports: - "8000:8000"` to `expose: - "8000"` for fastapi
+- Services are now only accessible internally through nginx
+
+### 3. Load Balancing Through Nginx
+- Nginx is configured to load balance between all instances
+- All external traffic goes through nginx on port 80
+- Frontend: `http://localhost`
+- API: `http://localhost/api/v1`
+
+## Usage
+
+### Standard (Single Instance)
+```bash
+docker compose up -d
+```
+
+### Scaled (Multiple Instances)
+```bash
+# Using the provided script
+./run-scaled.sh
+
+# Or manually
+docker compose up -d --scale frontend=2 --scale fastapi=2
+```
+
+### Check Status
+```bash
+docker compose ps
+```
+
+### View Logs
+```bash
+docker compose logs -f
+```
+
+### Stop Services
+```bash
+docker compose down
+```
+
+## Benefits
+- **High Availability**: Multiple instances provide redundancy
+- **Load Distribution**: Requests are distributed across instances
+- **Zero Downtime**: Can scale up/down without port conflicts
+- **Simple Access**: Single entry point through nginx (port 80)
+
+## Development Mode
+For development, the override file (`docker-compose.override.yml`) still works normally with hot reload and development settings.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
 
   fastapi:
     build: ./backend
-    container_name: fastapi_app
     restart: unless-stopped
     environment:
       - DATABASE_URL=postgresql://pm_user:pm_password@pm_postgres_db:5432/pm_database
@@ -28,8 +27,8 @@ services:
     volumes:
       - ./backend:/app
       - ./uploads:/app/uploads
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health", "||", "wget", "--spider", "-q", "http://localhost:8000/health"]
       interval: 30s
@@ -68,7 +67,6 @@ services:
 
   frontend:
     build: ./frontend
-    container_name: nextjs_frontend
     restart: unless-stopped
     environment:
       - NODE_ENV=production
@@ -76,8 +74,8 @@ services:
       - NEXTAUTH_SECRET=your-nextauth-secret-key-change-in-production
       - BACKEND_URL=http://fastapi:8000
       - NEXT_PUBLIC_BACKEND_URL=http://localhost/api/v1
-    ports:
-       - "3000:3000"
+    expose:
+      - "3000"
     depends_on:
       fastapi:
         condition: service_healthy

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -11,6 +11,7 @@ upstream fastapi_backend {
 
 upstream nextjs_frontend {
     least_conn;
+    # Docker Compose will automatically resolve 'frontend' to all scaled instances
     server frontend:3000 max_fails=3 fail_timeout=30s;
     keepalive 32;
 }

--- a/run-scaled.sh
+++ b/run-scaled.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "Starting services with scaling..."
+echo "Frontend: 2 instances"
+echo "FastAPI: 2 instances"
+echo ""
+echo "All traffic will be routed through nginx on port 80"
+echo "Frontend will be accessible at: http://localhost"
+echo "API will be accessible at: http://localhost/api/v1"
+echo ""
+
+# Stop any existing containers
+docker compose down
+
+# Start with scaling
+docker compose up -d --scale frontend=2 --scale fastapi=2
+
+echo ""
+echo "Services started!"
+echo "Check status with: docker compose ps"
+echo "View logs with: docker compose logs -f"
+echo "Stop with: docker compose down"


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable Docker Compose service scaling by removing fixed container names and using internal port exposure with Nginx for load balancing.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous setup caused "port is already allocated" errors when scaling `frontend` or `fastapi` services, as multiple instances attempted to bind to the same host port. This PR resolves that by allowing Docker Compose to manage container names for scaled services and configuring Nginx to act as a single entry point and load balancer for all scaled instances, making services accessible internally only.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e274b0a-5ed2-4871-bd49-f1a9749b4c22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e274b0a-5ed2-4871-bd49-f1a9749b4c22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>