### PR TITLE
Install python dependencies

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libc6-dev \
     libpq-dev \
+    python3-dev \
+    build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -37,7 +39,7 @@ RUN groupadd -g 1000 appuser && \
 # Copy requirements and install Python dependencies
 COPY requirements.txt requirements-dev.txt ./
 RUN pip install --upgrade pip setuptools wheel && \
-    pip install -r requirements.txt -r requirements-dev.txt
+    pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
 
 # Create necessary directories
 RUN mkdir -p uploads/{images,documents,videos,audio,temp} tmp && \
@@ -56,7 +58,7 @@ FROM base AS deps
 # Copy requirements and install Python dependencies
 COPY requirements.txt ./
 RUN pip install --upgrade pip setuptools wheel && \
-    pip install -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt
 
 # Production stage
 FROM base AS production
@@ -129,4 +131,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 
 EXPOSE 8000
 
-CMD ["/app/start.sh"] 
+CMD ["/app/start.sh"]
+
+# Alias for fastapi target (for compatibility)
+FROM production AS fastapi 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix Docker build errors by adding missing dependencies, improving pip installation, and aliasing a `fastapi` build target.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The build was failing due to `psycopg2-binary` compilation issues caused by missing system libraries (`python3-dev`, `build-essential`, `libpq-dev`). Additionally, a `fastapi` build target was being used externally, which didn't exist in the Dockerfile, leading to build failures. These changes ensure `psycopg2-binary` installs correctly and the `fastapi` target is recognized.

---
<a href="https://cursor.com/background-agent?bcId=bc-489c2704-84e8-42d0-b1ce-0e75c7ab6dd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-489c2704-84e8-42d0-b1ce-0e75c7ab6dd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>