### PR TITLE
Wait for database authentication

### DIFF
--- a/.env.backup.new
+++ b/.env.backup.new
@@ -1,0 +1,28 @@
+# Production Environment Configuration
+# NextAuth.js configuration
+NEXTAUTH_URL=http://206.189.89.239
+NEXTAUTH_SECRET=b9dc9437cd27ef4566cef5e97713b4de95e2f56bcb770ad272fc68d725bdb17b
+
+# Backend configuration  
+BACKEND_URL=http://fastapi:8000
+NEXT_PUBLIC_BACKEND_URL=http://206.189.89.239/api/v1
+
+# Database configuration
+DATABASE_URL=postgresql://pm_user:QlILLYN4kmmkuDzNwGrEsBQ4M@pm_postgres_db:5432/pm_database
+POSTGRES_PASSWORD=QlILLYN4kmmkuDzNwGrEsBQ4M
+
+# Redis configuration
+REDIS_PASSWORD=IvCF3RdLEUMjPRBFGQ2R3TBPU
+
+# Security keys
+SECRET_KEY=52b25338d9169462ec5fb249cf6ff05492c0e4c9a22b172c668bdbdaae112a5a
+
+# Node environment
+NODE_ENV=production
+
+# Monitoring
+GRAFANA_ADMIN_PASSWORD=nLQiqVlIL9WU
+
+# Optional: SSL configuration
+# SSL_CERT_PATH=/etc/nginx/ssl/cert.pem
+# SSL_KEY_PATH=/etc/nginx/ssl/key.pem

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - DEBUG=True
       - LOG_LEVEL=DEBUG
-      - DATABASE_URL=postgresql://pm_user:pm_password@pm_postgres_db:5432/pm_database
+      - DATABASE_URL=postgresql://pm_user:QlILLYN4kmmkuDzNwGrEsBQ4M@pm_postgres_db:5432/pm_database
     volumes:
       - ./backend:/app:rw
     read_only: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     build: ./backend
     restart: unless-stopped
     environment:
-      - DATABASE_URL=postgresql://pm_user:pm_password@pm_postgres_db:5432/pm_database
+      - DATABASE_URL=postgresql://pm_user:QlILLYN4kmmkuDzNwGrEsBQ4M@pm_postgres_db:5432/pm_database
       - SECRET_KEY=your-secret-key-here
       - REDIS_HOST=redis
       - REDIS_PORT=6379
@@ -45,7 +45,7 @@ services:
     environment:
       POSTGRES_DB: pm_database
       POSTGRES_USER: pm_user
-      POSTGRES_PASSWORD: pm_password
+      POSTGRES_PASSWORD: QlILLYN4kmmkuDzNwGrEsBQ4M
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql


### PR DESCRIPTION
Fix PostgreSQL authentication by correcting `DATABASE_URL` format in `.env` and synchronizing database passwords across `.env` and Docker Compose files.

The FastAPI application failed to connect to PostgreSQL due to a "password authentication failed" error. This was caused by a line break in the `DATABASE_URL` in the `.env` file and a mismatch between the password used by the application (from `.env`) and the one configured for the PostgreSQL container in `docker-compose.yml` and `docker-compose.override.yml`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ab3358a-e57d-4561-8de5-1682380b56ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ab3358a-e57d-4561-8de5-1682380b56ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>