### PR TITLE
Check backend for 404 error

### DIFF
--- a/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -7,7 +7,7 @@ interface ExtendedUser extends User {
   token?: string;
 }
 
-const handler = NextAuth({
+const authOptions = {
   providers: [
     CredentialsProvider({
       name: "Credentials",
@@ -101,7 +101,7 @@ const handler = NextAuth({
     signOut: '/api/auth/signout'
   },
   session: {
-    strategy: "jwt",
+    strategy: "jwt" as const,
     maxAge: 24 * 60 * 60, // 24 hours
   },
   callbacks: {
@@ -122,7 +122,7 @@ const handler = NextAuth({
         }
       };
     },
-    async redirect({ url, baseUrl }) {
+    async redirect({ url, baseUrl }: { url: string; baseUrl: string }) {
       // Ensure redirects stay within the app
       if (url.startsWith("/")) return `${baseUrl}${url}`;
       if (new URL(url).origin === baseUrl) return url;
@@ -137,6 +137,8 @@ const handler = NextAuth({
       console.log('User signed out');
     }
   }
-});
+};
+
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes TypeScript errors in NextAuth configuration to enable the `/api/auth/providers` endpoint.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The original NextAuth configuration contained TypeScript errors, specifically in the `redirect` callback's parameter types and the `session.strategy` definition. These errors prevented the successful build of the frontend, which in turn caused the `/api/auth/providers` endpoint (and other NextAuth-generated endpoints) to not be available, resulting in a 404 error. This PR resolves these type issues, allowing NextAuth to build and function correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-6039442f-0e7c-4557-97ea-6e223c65e92e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6039442f-0e7c-4557-97ea-6e223c65e92e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>