### PR TITLE
Fix duplicate nginx admin location

### DIFF
--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -309,26 +309,6 @@ http {
             add_header Cache-Control "public";
         }
 
-        # Admin dashboard - proxy to FastAPI SQLAlchemy Admin
-        location /admin {
-            # Optional: Add authentication
-            # auth_basic "Admin Area";
-            # auth_basic_user_file /etc/nginx/.htpasswd;
-            
-            proxy_pass http://fastapi_backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            
-            # Cache control
-            add_header Cache-Control "no-cache, no-store, must-revalidate";
-            
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
-        }
-
         # All other requests go to Next.js frontend
         location / {
             proxy_pass http://nextjs_frontend;


### PR DESCRIPTION
Remove duplicate `/admin` Nginx location block to resolve startup configuration error.

Nginx failed to start with an `[emerg] duplicate location "/admin"` error because `nginx.prod.conf` contained two identical `location /admin` blocks. One of these duplicate blocks has been removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-d39f3332-da70-4332-8f31-defe95c0f51a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d39f3332-da70-4332-8f31-defe95c0f51a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>