### PR TITLE
Process nginx logs for signout redirects

### DIFF
--- a/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -98,7 +98,7 @@ const authOptions = {
   pages: {
     signIn: '/signin',
     error: '/auth/error',
-    signOut: '/auth/signout'
+    signOut: '/signin'
   },
   session: {
     strategy: "jwt" as const,

--- a/frontend/src/app/api/auth/signout/route.ts
+++ b/frontend/src/app/api/auth/signout/route.ts
@@ -82,6 +82,6 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  // Handle POST requests for signout (redirect to GET)
-  return NextResponse.redirect(new URL('/api/auth/signout', request.url));
+  // Handle POST requests for signout (redirect directly to signin page)
+  return NextResponse.redirect(new URL('/signin', request.url));
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Redirect users directly to the sign-in page after logout to improve user experience and align NextAuth configuration.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous setup caused a 307 redirect from `POST /api/auth/signout` to `GET /api/auth/signout`, which displayed a confirmation page instead of immediately redirecting to the sign-in page. This PR updates the signout route handler and NextAuth configuration to ensure a direct redirect to `/signin` after logout.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ea95078-4281-4e84-8d43-2c274d335a8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ea95078-4281-4e84-8d43-2c274d335a8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>