### PR TITLE
Investigate sign out address invalid error

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -129,6 +129,6 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 
 # Environment variables for runtime
 ENV PORT=3000 \
-    HOSTNAME="0.0.0.0"
+    HOSTNAME="localhost"
 
 CMD ["/app/start.sh"] 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -100,6 +100,6 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 
 # Environment variables for runtime
 ENV PORT=3000 \
-    HOSTNAME="0.0.0.0"
+    HOSTNAME="localhost"
 
 CMD ["/app/start.sh"]

--- a/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -127,6 +127,13 @@ const authOptions = {
     },
     async redirect({ url, baseUrl }: { url: string; baseUrl: string }) {
       console.log('NextAuth redirect called with:', { url, baseUrl });
+      
+      // Prevent invalid URLs like 0.0.0.0
+      if (baseUrl.includes('0.0.0.0')) {
+        console.log('Detected invalid 0.0.0.0 baseUrl, using fallback');
+        baseUrl = process.env.NEXTAUTH_URL || 'http://localhost';
+      }
+      
       // Ensure redirects stay within the app
       if (url.startsWith("/")) {
         const redirectUrl = `${baseUrl}${url}`;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -88,7 +88,7 @@ export default function Dashboard() {
             </div>
           ) : (
             <button
-              onClick={() => signOut({ callbackUrl: '/signin' })}
+              onClick={() => logout()}
               className="px-6 py-2 bg-gray-200 text-indigo-700 rounded-lg shadow hover:bg-gray-300 transition"
             >
               Sign Out

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 import { useSession, signOut, getSession } from 'next-auth/react';
 import { useCallback } from 'react';
 import { authApi } from '../services/api';
+import { getAuthBaseUrl, getSignoutCallbackUrl } from '../lib/auth-utils';
 
 export const useAuth = () => {
   const { data: session, status } = useSession();
@@ -37,12 +38,13 @@ export const useAuth = () => {
       
       console.log('🚪 Attempting NextAuth signOut...');
       
-      // Use window.location.origin to ensure we have a proper base URL
-      const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+      // Get the proper callback URL for signout
+      const callbackUrl = getSignoutCallbackUrl();
+      console.log('Using callback URL for signout:', callbackUrl);
       
       // Then clear the NextAuth session with proper URL handling
       const signOutResult = await signOut({ 
-        callbackUrl: `${baseUrl}/signin`,
+        callbackUrl,
         redirect: false  // Keep false to prevent automatic redirect with invalid URLs
       });
       
@@ -51,7 +53,7 @@ export const useAuth = () => {
       // Manual redirect after successful signOut with proper URL
       console.log('🔄 Redirecting to signin page...');
       if (typeof window !== 'undefined') {
-        window.location.href = `${baseUrl}/signin`;
+        window.location.href = getSignoutCallbackUrl();
       }
       
     } catch (error) {
@@ -67,8 +69,7 @@ export const useAuth = () => {
       // Even if there's an error, try to redirect to signin page
       console.log('🔄 Fallback: redirecting to signin page...');
       if (typeof window !== 'undefined') {
-        const baseUrl = window.location.origin;
-        window.location.href = `${baseUrl}/signin`;
+        window.location.href = getSignoutCallbackUrl();
       }
     }
   }, [session, status]);

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -37,17 +37,22 @@ export const useAuth = () => {
       
       console.log('🚪 Attempting NextAuth signOut...');
       
-      // Then clear the NextAuth session
+      // Use window.location.origin to ensure we have a proper base URL
+      const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+      
+      // Then clear the NextAuth session with proper URL handling
       const signOutResult = await signOut({ 
-        callbackUrl: '/',
-        redirect: false  // Change this to false temporarily for debugging
+        callbackUrl: `${baseUrl}/signin`,
+        redirect: false  // Keep false to prevent automatic redirect with invalid URLs
       });
       
       console.log('✅ NextAuth signOut completed:', signOutResult);
       
-      // Manual redirect after successful signOut
-      console.log('🔄 Redirecting to home page...');
-      window.location.href = '/';
+      // Manual redirect after successful signOut with proper URL
+      console.log('🔄 Redirecting to signin page...');
+      if (typeof window !== 'undefined') {
+        window.location.href = `${baseUrl}/signin`;
+      }
       
     } catch (error) {
       console.error('❌ Logout error:', error);
@@ -58,11 +63,15 @@ export const useAuth = () => {
           stack: error.stack?.substring(0, 200)
         });
       }
-      // Force redirect to home page even if there's an error
-      console.log('🔄 Force redirecting due to error...');
-      window.location.href = '/';
+      
+      // Even if there's an error, try to redirect to signin page
+      console.log('🔄 Fallback: redirecting to signin page...');
+      if (typeof window !== 'undefined') {
+        const baseUrl = window.location.origin;
+        window.location.href = `${baseUrl}/signin`;
+      }
     }
-  }, [session, status]); // Add dependencies
+  }, [session, status]);
 
   const isAuthenticated = status === 'authenticated';
   const isLoading = status === 'loading';

--- a/frontend/src/lib/auth-utils.ts
+++ b/frontend/src/lib/auth-utils.ts
@@ -1,0 +1,54 @@
+/**
+ * Utility functions for handling authentication URLs across different environments
+ */
+
+/**
+ * Get the correct base URL for the current environment
+ * This prevents issues with invalid URLs like 0.0.0.0 in production
+ */
+export const getAuthBaseUrl = (): string => {
+  // In browser environment
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
+  }
+  
+  // Server-side environment
+  if (process.env.NEXTAUTH_URL) {
+    return process.env.NEXTAUTH_URL;
+  }
+  
+  // Fallbacks based on environment
+  if (process.env.NODE_ENV === 'production') {
+    return 'http://localhost';
+  }
+  
+  return 'http://localhost:3000';
+};
+
+/**
+ * Validate and sanitize a URL to prevent invalid addresses
+ */
+export const sanitizeUrl = (url: string): string => {
+  try {
+    // Check for invalid patterns
+    if (url.includes('0.0.0.0') || url.includes('127.0.0.1:3000')) {
+      console.warn('Invalid URL detected, using fallback:', url);
+      return getAuthBaseUrl();
+    }
+    
+    // Validate URL format
+    new URL(url);
+    return url;
+  } catch (error) {
+    console.warn('Invalid URL format, using fallback:', url, error);
+    return getAuthBaseUrl();
+  }
+};
+
+/**
+ * Get the correct callback URL for signout
+ */
+export const getSignoutCallbackUrl = (): string => {
+  const baseUrl = getAuthBaseUrl();
+  return `${baseUrl}/signin`;
+};


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix signout error by correcting invalid URL generation in NextAuth.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `net::ERR_ADDRESS_INVALID` error occurred because NextAuth was attempting to make requests to `0.0.0.0:3000`. This was caused by the Docker `HOSTNAME` environment variable being set to `0.0.0.0` and a lack of robust URL resolution within the NextAuth configuration and `useAuth` hook. This PR updates Dockerfiles, introduces URL sanitization utilities, and refactors NextAuth and `useAuth` to ensure correct base URL resolution and redirects across environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-0eceb9b5-9647-4172-bf7b-02b418e32b9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0eceb9b5-9647-4172-bf7b-02b418e32b9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>