### PR TITLE
Frontend build with type error

### DIFF
--- a/frontend/src/lib/axios.ts
+++ b/frontend/src/lib/axios.ts
@@ -90,4 +90,13 @@ api.interceptors.response.use(
   }
 );
 
+// Error handler function for use in stores and components
+export const handleApiError = (error: unknown): string => {
+  if (error instanceof Error) {
+    const apiError = error as ApiError;
+    return apiError.message || 'An unexpected error occurred';
+  }
+  return 'An unexpected error occurred';
+};
+
 export default api;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `handleApiError` to `axios.ts` to resolve a TypeScript compilation error during the frontend build.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `projectStore.ts` file was attempting to import `handleApiError` from `../lib/axios`, but this function was not exported, causing a compilation failure during the Next.js build process. This change exports the necessary error handling utility.

---
<a href="https://cursor.com/background-agent?bcId=bc-c776865b-bd18-41cc-a2fd-962425c61acf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c776865b-bd18-41cc-a2fd-962425c61acf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>