### PR TITLE
Fix user profile type mismatch

### DIFF
--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -4,21 +4,8 @@ import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { authApi } from '../../services/api';
+import { authApi, User } from '../../services/api';
 import LoadingSpinner from '../../components/LoadingSpinner';
-
-interface UserProfile {
-  id: number;
-  username: string;
-  email: string;
-  first_name: string;
-  last_name: string;
-  phone?: string;
-  role: string;
-  is_active: boolean;
-  created_at: string;
-  updated_at: string;
-}
 
 interface PropertyAccess {
   property_id: number;
@@ -45,7 +32,7 @@ export default function ProfilePage() {
   const { data: session, status } = useSession();
   const router = useRouter();
   
-  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [profile, setProfile] = useState<User | null>(null);
   const [propertyAccess, setPropertyAccess] = useState<PropertyAccess[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isEditing, setIsEditing] = useState(false);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3,14 +3,16 @@ import { AxiosResponse } from 'axios';
 
 // Types
 export interface User {
-  id: string;
+  id: number;
   username: string;
   email: string;
-  name: string;
+  first_name: string;
+  last_name: string;
+  phone?: string;
   role: string;
-  avatar?: string;
-  createdAt: string;
-  updatedAt: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface Project {

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -1,12 +1,6 @@
 // stores/auth-store.ts
 import { create } from 'zustand'
-import { authApi } from '@/services/api'
-
-interface User {
-  id: string
-  email: string
-  name: string
-}
+import { authApi, User } from '@/services/api'
 
 interface AuthState {
   user: User | null


### PR DESCRIPTION
Unify and correct frontend `User` type definitions to resolve type mismatch errors.

The `authApi.me()` response type (`User`) was inconsistent with the `UserProfile` type used in the profile page and a separate `User` type in the auth store, leading to TypeScript errors. This PR updates all frontend `User` type definitions to match the backend schema.

---
<a href="https://cursor.com/background-agent?bcId=bc-c54e7431-7ddc-4cb3-941f-7b25f8dfdcb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c54e7431-7ddc-4cb3-941f-7b25f8dfdcb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

