### PR TITLE
Fix user profile type mismatch

### DIFF
--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -4,21 +4,10 @@ import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { authApi } from '../../services/api';
+import { authApi, User } from '../../services/api';
 import LoadingSpinner from '../../components/LoadingSpinner';
 
-interface UserProfile {
-  id: number;
-  username: string;
-  email: string;
-  first_name: string;
-  last_name: string;
-  phone?: string;
-  role: string;
-  is_active: boolean;
-  created_at: string;
-  updated_at: string;
-}
+interface UserProfile extends User {}
 
 interface PropertyAccess {
   property_id: number;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3,14 +3,27 @@ import { AxiosResponse } from 'axios';
 
 // Types
 export interface User {
-  id: string;
+  id: number;
   username: string;
   email: string;
-  name: string;
+  first_name: string;
+  last_name: string;
+  phone?: string;
   role: string;
-  avatar?: string;
-  createdAt: string;
-  updatedAt: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LoginResponse {
+  id: number;
+  username: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  role: string;
+  token: string;
+  name: string; // For NextAuth compatibility
 }
 
 export interface Project {
@@ -58,7 +71,7 @@ interface ApiResponse<T> {
 // Auth API
 export const authApi = {
   login: async (credentials: { username: string; password: string }) => {
-    const response: AxiosResponse<ApiResponse<{ user: User; token: string }>> = 
+    const response: AxiosResponse<ApiResponse<LoginResponse>> = 
       await api.post('/api/v1/auth/login', credentials);
     return response.data;
   },

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -1,15 +1,15 @@
 // stores/auth-store.ts
 import { create } from 'zustand'
-import { authApi } from '@/services/api'
+import { authApi, User } from '@/services/api'
 
-interface User {
+interface AuthUser {
   id: string
   email: string
   name: string
 }
 
 interface AuthState {
-  user: User | null
+  user: AuthUser | null
   token: string | null
   isAuthenticated: boolean
   loading: boolean
@@ -17,7 +17,7 @@ interface AuthState {
   login: (credentials: { username: string; password: string }) => Promise<void>
   logout: () => void
   setToken: (token: string) => void
-  setUser: (user: User) => void
+  setUser: (user: AuthUser) => void
   clearError: () => void
 }
 
@@ -41,7 +41,13 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         // Get user data
         const userResponse = await authApi.me()
         if (userResponse.success) {
-          get().setUser(userResponse.data)
+          // Map API User to AuthUser
+          const authUser: AuthUser = {
+            id: userResponse.data.id.toString(),
+            email: userResponse.data.email,
+            name: `${userResponse.data.first_name} ${userResponse.data.last_name}`
+          }
+          get().setUser(authUser)
         }
       }
     } catch (error: any) {
@@ -71,7 +77,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     set({ token, isAuthenticated: true })
   },
   
-  setUser: (user: User) => {
+  setUser: (user: AuthUser) => {
     set({ user })
   },
   


### PR DESCRIPTION
Align `User` type definitions with backend schema and refactor auth store to resolve type errors.

The `User` interface in `api.ts` was out of sync with the actual backend `User` schema and the `UserProfile` interface used on the profile page, causing a type mismatch. This PR updates the `User` interface to reflect the backend's snake_case fields and structure, introduces a `LoginResponse` for NextAuth's `name` field, and refactors the auth store to use a consistent `AuthUser` type for internal state management.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c3fb890-bfb4-47a0-a1f6-51fe2f9169b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c3fb890-bfb4-47a0-a1f6-51fe2f9169b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

