### PR TITLE
Investigate production login redirect to localhost

### DIFF
--- a/frontend/src/lib/auth-utils.ts
+++ b/frontend/src/lib/auth-utils.ts
@@ -12,14 +12,24 @@ export const getAuthBaseUrl = (): string => {
     return window.location.origin;
   }
   
-  // Server-side environment
+  // Server-side environment - try NEXTAUTH_URL first
   if (process.env.NEXTAUTH_URL) {
     return process.env.NEXTAUTH_URL;
   }
   
   // Fallbacks based on environment
   if (process.env.NODE_ENV === 'production') {
-    return 'http://localhost';
+    // Try to get from NEXT_PUBLIC_BACKEND_URL and extract base URL
+    if (process.env.NEXT_PUBLIC_BACKEND_URL) {
+      try {
+        const url = new URL(process.env.NEXT_PUBLIC_BACKEND_URL);
+        return `${url.protocol}//${url.host}`;
+      } catch (error) {
+        console.warn('Failed to parse NEXT_PUBLIC_BACKEND_URL:', error);
+      }
+    }
+    // Final fallback for production
+    return 'http://206.189.89.239';
   }
   
   return 'http://localhost:3000';


### PR DESCRIPTION
Prevent production login redirects to localhost by updating the authentication base URL logic.

The previous implementation had a hardcoded `http://localhost` fallback in `auth-utils.ts` for production environments when `NEXTAUTH_URL` was not available, causing incorrect redirects. This PR replaces that with the correct production IP and adds a more robust fallback using `NEXT_PUBLIC_BACKEND_URL`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3abaaa6-f5a6-42db-946a-8c670c9733ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3abaaa6-f5a6-42db-946a-8c670c9733ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

