### PR TITLE
Fix admin router attribute error

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -48,7 +48,7 @@ static_path.mkdir(exist_ok=True)
 app.mount("/static", StaticFiles(directory=str(static_path)), name="static")
 
 # Initialize SQLAdmin with proper configuration
-admin = Admin(
+sqladmin_instance = Admin(
     app, 
     engine,
     title="PM System Admin",
@@ -313,15 +313,15 @@ class NotificationAdmin(ModelView, model=Notification):
     can_view_details = True
 
 # Register all admin views
-admin.add_view(UserAdmin)
-admin.add_view(PropertyAdmin)
-admin.add_view(RoomAdmin)
-admin.add_view(MachineAdmin)
-admin.add_view(IssueAdmin)
-admin.add_view(PMScheduleAdmin)
-admin.add_view(WorkOrderAdmin)
-admin.add_view(JobAdmin)
-admin.add_view(NotificationAdmin)
+sqladmin_instance.add_view(UserAdmin)
+sqladmin_instance.add_view(PropertyAdmin)
+sqladmin_instance.add_view(RoomAdmin)
+sqladmin_instance.add_view(MachineAdmin)
+sqladmin_instance.add_view(IssueAdmin)
+sqladmin_instance.add_view(PMScheduleAdmin)
+sqladmin_instance.add_view(WorkOrderAdmin)
+sqladmin_instance.add_view(JobAdmin)
+sqladmin_instance.add_view(NotificationAdmin)
 
 # Include API routers
 app.include_router(auth.router, prefix="/api/v1")


### PR DESCRIPTION
Rename `sqladmin` instance to `sqladmin_instance` to resolve a naming conflict and `AttributeError`.

The `admin` variable was being used for both the `sqladmin` instance and the FastAPI router imported from `routes.admin`. This caused an `AttributeError` when `app.include_router(admin.router)` was called, as the `sqladmin` instance does not have a `router` attribute. Renaming the `sqladmin` instance clarifies the variable's purpose and resolves the conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-a37b423a-8de4-49cb-956d-6a543fe272b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a37b423a-8de4-49cb-956d-6a543fe272b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

