### PR TITLE
Fix admin router attribute error

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -48,7 +48,7 @@ static_path.mkdir(exist_ok=True)
 app.mount("/static", StaticFiles(directory=str(static_path)), name="static")
 
 # Initialize SQLAdmin with proper configuration
-admin = Admin(
+sql_admin = Admin(
     app, 
     engine,
     title="PM System Admin",
@@ -313,15 +313,15 @@ class NotificationAdmin(ModelView, model=Notification):
     can_view_details = True
 
 # Register all admin views
-admin.add_view(UserAdmin)
-admin.add_view(PropertyAdmin)
-admin.add_view(RoomAdmin)
-admin.add_view(MachineAdmin)
-admin.add_view(IssueAdmin)
-admin.add_view(PMScheduleAdmin)
-admin.add_view(WorkOrderAdmin)
-admin.add_view(JobAdmin)
-admin.add_view(NotificationAdmin)
+sql_admin.add_view(UserAdmin)
+sql_admin.add_view(PropertyAdmin)
+sql_admin.add_view(RoomAdmin)
+sql_admin.add_view(MachineAdmin)
+sql_admin.add_view(IssueAdmin)
+sql_admin.add_view(PMScheduleAdmin)
+sql_admin.add_view(WorkOrderAdmin)
+sql_admin.add_view(JobAdmin)
+sql_admin.add_view(NotificationAdmin)
 
 # Include API routers
 app.include_router(auth.router, prefix="/api/v1")


### PR DESCRIPTION
Rename SQLAdmin object to `sql_admin` to resolve `AttributeError: 'Admin' object has no attribute 'router'` caused by a variable name conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e75be9a-3968-4847-a27d-ffae3984d50f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e75be9a-3968-4847-a27d-ffae3984d50f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

